### PR TITLE
Date separator fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,12 +42,18 @@ function checkBtnHandler(){
     var isLeapYearMessage;
 
     if(date){
+		var dateRegExp = /\d{1,2}[\/\-]\d{1,2}[\/\-]\d{4}/g;
+		var dateRegExpVal = dateRegExp.test(date);
+
         var dateArray= date.split(/[/,-]+/);
         var dd=dateArray[0];
         var mm=dateArray[1];
         var yy=dateArray[2];
 
 		if(date.length>10){
+            output.innerText = error;
+		}
+		else if(!dateRegExpVal){
             output.innerText = error;
 		}
         else if(isNaN(dd) || isNaN(mm) || isNaN(yy)){

--- a/app.js
+++ b/app.js
@@ -47,7 +47,10 @@ function checkBtnHandler(){
         var mm=dateArray[1];
         var yy=dateArray[2];
 
-        if(isNaN(dd) || isNaN(mm) || isNaN(yy)){
+		if(date.length>10){
+            output.innerText = error;
+		}
+        else if(isNaN(dd) || isNaN(mm) || isNaN(yy)){
             output.innerText = error;
         }
         else if(!Number.isInteger(Number(dd)) || !Number.isInteger(Number(mm)) || !Number.isInteger(Number(yy))){


### PR DESCRIPTION
The date input field is accepting inputs with multiple date separators in any order of `/` and `-`, as seen in the pictures below.

<img src="https://user-images.githubusercontent.com/50140864/102520027-4115b080-40b9-11eb-9b7f-e932b0d486c2.png" width="50%" />
<img src="https://user-images.githubusercontent.com/50140864/102520104-5a1e6180-40b9-11eb-8fff-6c1e67038aa4.png" width="50%" />

To counter this, I made two changes:
- I capped the date length to 10 characters.
- I added a RegEx to mainly prevent the repetition of the date separators, for eg: `6/-6-/2000`.